### PR TITLE
Adding source API's for updating source address.

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -236,6 +236,17 @@ func (p *Pinger) Addr() string {
 	return p.addr
 }
 
+// SetSource sets the ip address of the source host, source should
+// be like "127.0.0.1".
+func (p *Pinger) SetSource(source string) {
+	p.source = source
+}
+
+// Addr returns the string ip address of the source host.
+func (p *Pinger) Source() string {
+	return p.source
+}
+
 // SetPrivileged sets the type of ping pinger will send.
 // false means pinger will send an "unprivileged" UDP ping.
 // true means pinger will send a "privileged" raw ICMP ping.

--- a/ping.go
+++ b/ping.go
@@ -142,6 +142,8 @@ type Pinger struct {
 	size     int
 	sequence int
 	network  string
+	// Hostname for debugging purposes.
+	hostname string
 }
 
 type packet struct {
@@ -245,6 +247,16 @@ func (p *Pinger) SetSource(source string) {
 // Addr returns the string ip address of the source host.
 func (p *Pinger) Source() string {
 	return p.source
+}
+
+// SetHostname sets the hostname of the source host
+func (p *Pinger) SetHostname(hostname string) {
+	p.hostname = hostname
+}
+
+// Hostname returns the Hostname of the source host.
+func (p *Pinger) Hostname() string {
+	return p.hostname
 }
 
 // SetPrivileged sets the type of ping pinger will send.


### PR DESCRIPTION
***Why:***
Giving an option for the application to add the source address instead of getting resolved underneath the kernel by providing API's to set the source address

Also, added API's for updating the hostname.

@sparrc Can you please review the change ?