### PR TITLE
remove signal handler, add Stop method

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -48,8 +48,6 @@ import (
 	"math"
 	"math/rand"
 	"net"
-	"os"
-	"os/signal"
 	"sync"
 	"syscall"
 	"time"
@@ -286,14 +284,9 @@ func (p *Pinger) run() {
 
 	timeout := time.NewTicker(p.Timeout)
 	interval := time.NewTicker(p.Interval)
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-	signal.Notify(c, syscall.SIGTERM)
 
 	for {
 		select {
-		case <-c:
-			close(p.done)
 		case <-p.done:
 			wg.Wait()
 			return
@@ -319,6 +312,10 @@ func (p *Pinger) run() {
 			}
 		}
 	}
+}
+
+func (p *Pinger) Stop() {
+	close(p.done)
 }
 
 func (p *Pinger) finish() {


### PR DESCRIPTION
A packet should not handle signal itself. Otherwise, it will affect the user's own signal handler and cause the program can not be stopped normally and some other problem.
Maybe add a Stop method to allow user to interrupt ping.