### PR TITLE
Added ICMP Packet ID to distinguish ICMP replies in multithreading environment

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -90,10 +90,10 @@ func NewPinger(addr string) (*Pinger, error) {
 		Interval: time.Second,
 		Timeout:  time.Second * 100000,
 		Count:    -1,
-
-		network: "udp",
-		ipv4:    ipv4,
-		size:    timeSliceLength,
+		id:       rand.Intn(0xffff),
+		network:  "udp",
+		ipv4:     ipv4,
+		size:     timeSliceLength,
 
 		done: make(chan bool),
 	}, nil
@@ -140,6 +140,7 @@ type Pinger struct {
 	ipv4     bool
 	source   string
 	size     int
+	id       int
 	sequence int
 	network  string
 }
@@ -427,6 +428,12 @@ func (p *Pinger) processPacket(recv *packet) error {
 		return nil
 	}
 
+	// Check if reply from same ID
+	body := m.Body.(*icmp.Echo)
+	if body.ID != p.id {
+		return nil
+	}
+
 	outPkt := &Packet{
 		Nbytes: recv.nbytes,
 		IPAddr: p.ipaddr,
@@ -472,7 +479,7 @@ func (p *Pinger) sendICMP(conn *icmp.PacketConn) error {
 	bytes, err := (&icmp.Message{
 		Type: typ, Code: 0,
 		Body: &icmp.Echo{
-			ID:   rand.Intn(65535),
+			ID:   p.id,
 			Seq:  p.sequence,
 			Data: t,
 		},


### PR DESCRIPTION
When using the library to ping different hosts simultaneously the previous implementation, not setting/checking ICMP packet ID, will mix replies.