### PR TITLE
fix duplicate field network and ipv4 error

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -94,11 +94,8 @@ func NewPinger(addr string) (*Pinger, error) {
 		network:  "udp",
 		ipv4:     ipv4,
 		size:     timeSliceLength,
-		network: "udp",
-		ipv4:    ipv4,
-		Size:    timeSliceLength,
-
-		done: make(chan bool),
+		Size:     timeSliceLength,
+		done:     make(chan bool),
 	}, nil
 }
 


### PR DESCRIPTION
error like:
`
vendor/github.com/sparrc/go-ping/ping.go:97:10: duplicate field name in struct literal: network
vendor/github.com/sparrc/go-ping/ping.go:98:7: duplicate field name in struct literal: ipv4
`