### PR TITLE
Include adddress in Packet

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -161,6 +161,9 @@ type Packet struct {
 	// IPAddr is the address of the host being pinged.
 	IPAddr *net.IPAddr
 
+	// Addr is the string address of the host being pinged.
+	Addr string
+
 	// NBytes is the number of bytes in the message.
 	Nbytes int
 
@@ -440,6 +443,7 @@ func (p *Pinger) processPacket(recv *packet) error {
 	outPkt := &Packet{
 		Nbytes: recv.nbytes,
 		IPAddr: p.ipaddr,
+		Addr: p.addr,
 	}
 
 	switch pkt := m.Body.(type) {


### PR DESCRIPTION
Include the original address in the Packet type for use in
`pinger.OnRecv()`.