### PR TITLE
Increase performance and prevent panic

### DIFF
--- a/cmd/ping/ping.go
+++ b/cmd/ping/ping.go
@@ -65,8 +65,8 @@ func main() {
 	}()
 
 	pinger.OnRecv = func(pkt *ping.Packet) {
-		fmt.Printf("%d bytes from %s: icmp_seq=%d time=%v\n",
-			pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt)
+		fmt.Printf("%d bytes from %s: icmp_seq=%d time=%v ttl=%v\n",
+			pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt, pkt.Ttl)
 	}
 	pinger.OnFinish = func(stats *ping.Statistics) {
 		fmt.Printf("\n--- %s ping statistics ---\n", stats.Addr)

--- a/ping.go
+++ b/ping.go
@@ -220,11 +220,6 @@ type Statistics struct {
 	StdDevRtt time.Duration
 }
 
-// GetIpv4 returns whether ipv4 is used.
-func (p *Pinger) GetIpv4() bool {
-	return p.ipv4
-}
-
 // SetIPAddr sets the ip address of the target host.
 func (p *Pinger) SetIPAddr(ipaddr *net.IPAddr) {
 	var ipv4 bool
@@ -463,18 +458,13 @@ func (p *Pinger) recvICMP(conn *icmp.PacketConn, recv chan<- *packet, wg *sync.W
 			if err != nil {
 				if neterr, ok := err.(*net.OpError); ok {
 					if neterr.Timeout() {
-						if n > 0 {
-							fmt.Println("Timed out, got: ", bytesReceived[:n])
-						}
-						// Read timeout
 						continue
 					} else {
 						close(p.done)
 						return
 					}
 				}
-				// do something with other error
-				fmt.Println("Some other error - ", err.Error())
+				continue
 			}
 
 			recv <- &packet{bytes: bytesReceived[:n], nbytes: n, ttl: ttl}
@@ -522,7 +512,7 @@ func (p *Pinger) processPacket(recv *packet) error {
 		if len(pkt.Data) < timeSliceLength+trackerLength {
 			return errors.New("insufficient data received")
 		}
-		// todo: check if we can cache
+
 		tracker := bytesToInt(pkt.Data[timeSliceLength:])
 		timestamp := bytesToTime(pkt.Data[:timeSliceLength])
 

--- a/ping.go
+++ b/ping.go
@@ -154,6 +154,7 @@ type Pinger struct {
 type packet struct {
 	bytes  []byte
 	nbytes int
+	ttl    int
 }
 
 // Packet represents a received and processed ICMP echo packet.
@@ -172,6 +173,9 @@ type Packet struct {
 
 	// Seq is the ICMP sequence number.
 	Seq int
+
+	// TTL is the TTL on the packet
+	Ttl int
 }
 
 // Statistics represent the stats of a currently running or finished
@@ -276,10 +280,12 @@ func (p *Pinger) run() {
 		if conn = p.listen(ipv4Proto[p.network], p.source); conn == nil {
 			return
 		}
+		conn.IPv4PacketConn().SetControlMessage(ipv4.FlagTTL, true)
 	} else {
 		if conn = p.listen(ipv6Proto[p.network], p.source); conn == nil {
 			return
 		}
+		conn.IPv6PacketConn().SetControlMessage(ipv6.FlagHopLimit, true)
 	}
 	defer conn.Close()
 	defer p.finish()
@@ -397,7 +403,21 @@ func (p *Pinger) recvICMP(
 		default:
 			bytes := make([]byte, 512)
 			conn.SetReadDeadline(time.Now().Add(time.Millisecond * 100))
-			n, _, err := conn.ReadFrom(bytes)
+			var n, ttl int
+			var err error
+			if p.ipv4 {
+				var cm *ipv4.ControlMessage
+				n, cm, _, err = conn.IPv4PacketConn().ReadFrom(bytes)
+				if cm != nil {
+					ttl = cm.TTL
+				}
+			} else {
+				var cm *ipv6.ControlMessage
+				n, cm, _, err = conn.IPv6PacketConn().ReadFrom(bytes)
+				if cm != nil {
+					ttl = cm.HopLimit
+				}
+			}
 			if err != nil {
 				if neterr, ok := err.(*net.OpError); ok {
 					if neterr.Timeout() {
@@ -410,7 +430,7 @@ func (p *Pinger) recvICMP(
 				}
 			}
 
-			recv <- &packet{bytes: bytes, nbytes: n}
+			recv <- &packet{bytes: bytes, nbytes: n, ttl: ttl}
 		}
 	}
 }
@@ -465,6 +485,7 @@ func (p *Pinger) processPacket(recv *packet) error {
 		Nbytes: recv.nbytes,
 		IPAddr: p.ipaddr,
 		Addr:   p.addr,
+		Ttl:    recv.ttl,
 	}
 
 	switch pkt := m.Body.(type) {

--- a/ping.go
+++ b/ping.go
@@ -174,7 +174,7 @@ type Packet struct {
 	// Seq is the ICMP sequence number.
 	Seq int
 
-	// TTL is the TTL on the packet
+	// TTL is the Time to Live on the packet.
 	Ttl int
 }
 
@@ -462,14 +462,14 @@ func (p *Pinger) processPacket(recv *packet) error {
 	}
 
 	body := m.Body.(*icmp.Echo)
-	// If we are priviledged, we can match icmp.ID
+	// If we are privileged, we can match icmp.ID
 	if p.network == "ip" {
 		// Check if reply from same ID
 		if body.ID != p.id {
 			return nil
 		}
 	} else {
-		// If we are not priviledged, we cannot set ID - require kernel ping_table map
+		// If we are not privileged, we cannot set ID - require kernel ping_table map
 		// need to use contents to identify packet
 		data := IcmpData{}
 		err := json.Unmarshal(body.Data, &data)


### PR DESCRIPTION
This PR:
1. Modularizes the `Run` function by moving listening and pinging functionality into separate functions.
2. Refactors code in several places for simplicity.

Closes #5 
Closes #44 
Closes #47
Addresses #16: adds error returns to several functions but does not remove Print statements for the sake of backwards compatibility.
Addresses #52: simplified serialization
