### PR TITLE
Fix runtime panic

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -440,7 +440,7 @@ func (p *Pinger) processPacket(recv *packet) error {
 	var proto int
 	if p.ipv4 {
 		if p.network == "ip" {
-			bytes = ipv4Payload(recv.bytes)
+			bytes = ipv4Payload(recv)
 		} else {
 			bytes = recv.bytes
 		}
@@ -589,11 +589,13 @@ func byteSliceOfSize(n int) []byte {
 	return b
 }
 
-func ipv4Payload(b []byte) []byte {
+func ipv4Payload(recv *packet) []byte {
+	b := recv.bytes
 	if len(b) < ipv4.HeaderLen {
 		return b
 	}
 	hdrlen := int(b[0]&0x0f) << 2
+	recv.nbytes -= hdrlen
 	return b[hdrlen:]
 }
 


### PR DESCRIPTION
Closes: #47

This PR fixes a panic runtime error in the `ipv4Payload` function by modifying the length of the packet bytes length when the header is removed. 