### PR TITLE
Make `processPacket` more performant

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -46,7 +46,6 @@ package ping
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -486,7 +485,8 @@ func (p *Pinger) processPacket(recv *packet) error {
 		}
 
 		if len(pkt.Data) < timeSliceLength+trackerLength {
-			return errors.New("insufficient data received")
+			fmt.Printf("insufficient data received; got: %d %v",
+				len(pkt.Data), pkt.Data)
 		}
 
 		tracker := bytesToInt(pkt.Data[timeSliceLength:])

--- a/ping.go
+++ b/ping.go
@@ -485,7 +485,7 @@ func (p *Pinger) processPacket(recv *packet) error {
 		}
 
 		if len(pkt.Data) < timeSliceLength+trackerLength {
-			fmt.Printf("insufficient data received; got: %d %v",
+			return fmt.Errorf("insufficient data received; got: %d %v",
 				len(pkt.Data), pkt.Data)
 		}
 

--- a/ping_test.go
+++ b/ping_test.go
@@ -1,10 +1,17 @@
 package ping
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
 	"net"
 	"runtime/debug"
 	"testing"
 	"time"
+
+	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv4"
+	"golang.org/x/net/ipv6"
 )
 
 func TestNewPingerValid(t *testing.T) {
@@ -262,5 +269,176 @@ func AssertTrue(t *testing.T, b bool) {
 func AssertFalse(t *testing.T, b bool) {
 	if b {
 		t.Errorf("Expected False, got True, Stack:\n%s", string(debug.Stack()))
+	}
+}
+
+func BenchmarkProcessPacket(b *testing.B) {
+	pinger, _ := NewPinger("127.0.0.1")
+
+	pinger.ipv4 = true
+	pinger.addr = "127.0.0.1"
+	pinger.network = "ip4:icmp"
+	pinger.id = 123
+	pinger.Tracker = 456
+
+	t := append(timeToBytes(time.Now()), intToBytes(pinger.Tracker)...)
+	if remainSize := pinger.Size - timeSliceLength - trackerLength; remainSize > 0 {
+		t = append(t, bytes.Repeat([]byte{1}, remainSize)...)
+	}
+
+	body := &icmp.Echo{
+		ID:   pinger.id,
+		Seq:  pinger.sequence,
+		Data: t,
+	}
+
+	msg := &icmp.Message{
+		Type: ipv4.ICMPTypeEchoReply,
+		Code: 0,
+		Body: body,
+	}
+
+	msgBytes, _ := msg.Marshal(nil)
+
+	pkt := packet{
+		nbytes: len(msgBytes),
+		bytes:  msgBytes,
+		ttl:    24,
+	}
+
+	for k := 0; k < b.N; k++ {
+		pinger.processPacket(&pkt)
+	}
+}
+
+func BenchmarkProcessPacketOld(b *testing.B) {
+	pinger, _ := NewPinger("127.0.0.1")
+
+	pinger.ipv4 = true
+	pinger.addr = "127.0.0.1"
+	pinger.network = "ip4:icmp"
+	pinger.id = 123
+	pinger.Tracker = 456
+
+	type IcmpData struct {
+		Bytes   []byte
+		Tracker int64
+	}
+
+	byteSliceOfSize := func(n int) []byte {
+		b := make([]byte, n)
+		for i := 0; i < len(b); i++ {
+			b[i] = 1
+		}
+
+		return b
+	}
+
+	t := timeToBytes(time.Now())
+	if pinger.Size-timeSliceLength != 0 {
+		t = append(t, byteSliceOfSize(pinger.Size-timeSliceLength)...)
+	}
+
+	data, _ := json.Marshal(IcmpData{Bytes: t, Tracker: pinger.Tracker})
+
+	body := &icmp.Echo{
+		ID:   pinger.id,
+		Seq:  pinger.sequence,
+		Data: data,
+	}
+
+	msg := &icmp.Message{
+		Type: ipv4.ICMPTypeEchoReply,
+		Code: 0,
+		Body: body,
+	}
+
+	msgBytes, _ := msg.Marshal(nil)
+
+	pkt := packet{
+		nbytes: len(msgBytes),
+		bytes:  msgBytes,
+	}
+
+	processPacket := func(p *Pinger, recv *packet) error {
+		var bytes []byte
+		var proto int
+		if p.ipv4 {
+			if p.network == "ip" {
+				bytes = ipv4Payload(recv.bytes)
+			} else {
+				bytes = recv.bytes
+			}
+			proto = protocolICMP
+		} else {
+			bytes = recv.bytes
+			proto = protocolIPv6ICMP
+		}
+
+		var m *icmp.Message
+		var err error
+		if m, err = icmp.ParseMessage(proto, bytes[:recv.nbytes]); err != nil {
+			return fmt.Errorf("Error parsing icmp message")
+		}
+
+		if m.Type != ipv4.ICMPTypeEchoReply && m.Type != ipv6.ICMPTypeEchoReply {
+			// Not an echo reply, ignore it
+			return nil
+		}
+
+		body := m.Body.(*icmp.Echo)
+		// If we are priviledged, we can match icmp.ID
+		if p.network == "ip" {
+			// Check if reply from same ID
+			if body.ID != p.id {
+				return nil
+			}
+		} else {
+			// If we are not priviledged, we cannot set ID - require kernel ping_table map
+			// need to use contents to identify packet
+			data := IcmpData{}
+			err := json.Unmarshal(body.Data, &data)
+			if err != nil {
+				return err
+			}
+			if data.Tracker != p.Tracker {
+				return nil
+			}
+		}
+
+		outPkt := &Packet{
+			Nbytes: recv.nbytes,
+			IPAddr: p.ipaddr,
+			Addr:   p.addr,
+			Ttl:    recv.ttl,
+		}
+
+		switch pkt := m.Body.(type) {
+		case *icmp.Echo:
+			data := IcmpData{}
+			err := json.Unmarshal(m.Body.(*icmp.Echo).Data, &data)
+			if err != nil {
+				return err
+			}
+			outPkt.Rtt = time.Since(bytesToTime(data.Bytes))
+			outPkt.Seq = pkt.Seq
+			p.PacketsRecv++
+		default:
+			// Very bad, not sure how this can happen
+			return fmt.Errorf("Error, invalid ICMP echo reply. Body type: %T, %s",
+				pkt, pkt)
+		}
+
+		p.rtts = append(p.rtts, outPkt.Rtt)
+		handler := p.OnRecv
+		if handler != nil {
+			handler(outPkt)
+		}
+
+		return nil
+	}
+
+	for k := 0; k < b.N; k++ {
+		processPacket(pinger, &pkt)
 	}
 }


### PR DESCRIPTION
Currently, encoding with `json`, the `processPacket` function is ~7x slower than using straight binary encoding.

```
# json encoding
BenchmarkProcessPacketOld-8   	 1000000	      2131 ns/op
# binary encoding
BenchmarkProcessPacket-8      	 5000000	       283 ns/op
```

I feel like this resolves #44 even though it isn't using gob, as it seems the goal of 44 was to use a faster encoding method.