### PR TITLE
Added PacketsRecvDup and fixed the count

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 ICMP Ping library for Go, inspired by
 [go-fastping](https://github.com/tatsushid/go-fastping)
 
+        修复了死锁问题，修复了PacketLoss为负数问题，增加了PacketsRecvDup重复返回计数。在原作者没接受PR之前可临时用这个分支
+
 Here is a very simple example that sends & receives 3 packets:
 
 ```go

--- a/cmd/ping/ping.go
+++ b/cmd/ping/ping.go
@@ -7,7 +7,7 @@ import (
 	"os/signal"
 	"time"
 
-	"github.com/sparrc/go-ping"
+	"github.com/davidhoo/go-ping"
 )
 
 var usage = `

--- a/ping.go
+++ b/ping.go
@@ -340,11 +340,12 @@ func (p *Pinger) run() {
 			if err != nil {
 				fmt.Println("FATAL: ", err.Error())
 			}
-		}
-		if p.Count > 0 && p.PacketsRecv >= p.Count && p.PacketsSent >= p.Count {
-			close(p.done)
-			wg.Wait()
-			return
+		default:
+			if p.Count > 0 && p.PacketsRecv >= p.Count && p.PacketsSent >= p.Count {
+				close(p.done)
+				wg.Wait()
+				return
+			}
 		}
 	}
 }

--- a/ping.go
+++ b/ping.go
@@ -340,12 +340,11 @@ func (p *Pinger) run() {
 			if err != nil {
 				fmt.Println("FATAL: ", err.Error())
 			}
-		default:
-			if p.Count > 0 && p.PacketsRecv >= p.Count && p.PacketsSent >= p.Count {
-				close(p.done)
-				wg.Wait()
-				return
-			}
+		}
+		if p.Count > 0 && p.PacketsRecv >= p.Count && p.PacketsSent >= p.Count {
+			close(p.done)
+			wg.Wait()
+			return
 		}
 	}
 }


### PR DESCRIPTION
In some cases, packets will be returned repeatedly, resulting in PacketsSend <PacketsRecv, at this time Statistics.Loss is negative. Therefore, PacketsRecvDup is added to distinguish between normal return packets and repeated return packets.

```bash
ping -c 4 vpn.sina.com                                                                                                                                                                                                                                                                     !570
PING vpn.sina.com (61.135.152.240): 56 data bytes
64 bytes from 61.135.152.240: icmp_seq=0 ttl=121 time=4.380 ms
64 bytes from 61.135.152.240: icmp_seq=0 ttl=121 time=4.433 ms (DUP!)
64 bytes from 61.135.152.240: icmp_seq=1 ttl=121 time=6.482 ms
64 bytes from 61.135.152.240: icmp_seq=1 ttl=121 time=6.560 ms (DUP!)
64 bytes from 61.135.152.240: icmp_seq=2 ttl=121 time=6.125 ms
64 bytes from 61.135.152.240: icmp_seq=2 ttl=121 time=6.191 ms (DUP!)
64 bytes from 61.135.152.240: icmp_seq=3 ttl=121 time=6.403 ms

--- vpn.sina.com ping statistics ---
4 packets transmitted, 4 packets received, +3 duplicates, 0.0% packet loss
round-trip min/avg/max/stddev = 4.380/5.796/6.560/0.890 ms
```
