### PR TITLE
Deadlock fix

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -434,7 +434,11 @@ func (p *Pinger) recvICMP(
 				}
 			}
 
-			recv <- &packet{bytes: bytes, nbytes: n, ttl: ttl}
+			select {
+			case <-p.done:
+				return
+			case recv <- &packet{bytes: bytes, nbytes: n, ttl: ttl}:
+			}
 		}
 	}
 }


### PR DESCRIPTION
Deadlock observed when starting multiple ping routines.
It happens when writting to `recv` channel (which is full) and no active
readers for this channel.

*Example to reproduce the issue* :

	var waiter sync.WaitGroup
	pingFunc := func() {
		defer waiter.Done()

		pinger, err := ping.NewPinger("8.8.8.8")
		if err != nil {
			return
		}

		pinger.SetPrivileged(true)
		pinger.Count = 5
		pinger.Interval = time.Second
		pinger.Timeout = time.Second * 4

		pinger.Run()
	}

	for i := 0; i < 1000; i++ {
		waiter.Add(1)
		go pingFunc()
	}

	waiter.Wait() // deadlock here! (reproducible almost every time)